### PR TITLE
Refactor/use source field to check in codeutil

### DIFF
--- a/pkg/codeutil/code_test.go
+++ b/pkg/codeutil/code_test.go
@@ -2,7 +2,6 @@ package codeutil_test
 
 import (
 	"encoding/base64"
-	"fmt"
 	"testing"
 
 	"github.com/OYE0303/expense-tracker-go/pkg/codeutil"
@@ -23,7 +22,9 @@ func (s *CodeUtilSuite) TestDecodeCursor() {
 		"when the encoded string is empty, return an error":   decodeCursor_EncodedEmptyString_ReturnErr,
 		"when the decoded string is empty, return an error":   decodeCursor_DecodedEmptyString_ReturnErr,
 		"when the cursor format is invalid, return an error":  decodeCursor_InvalidFormatCursor_ReturnErr,
+		"when the source field is not found, return an error": decodeCursor_SourceFieldNotFound_ReturnErr,
 		"when the encoded string is valid, return cursor map": decodeCursor_ValidEncodedString_ReturnCursorMap,
+		"when the source field is correct, return cursor map": decodeCursor_WithCorrectSourceField_ReturnCursorMap,
 	} {
 		s.Run(testutil.GetFunName(fn), func() {
 			fn(s, scenario)
@@ -36,7 +37,7 @@ func decodeCursor_EncodedEmptyString_ReturnErr(s *CodeUtilSuite, desc string) {
 	encodedString := ""
 
 	// action
-	result, err := codeutil.DecodeCursor(encodedString)
+	result, err := codeutil.DecodeCursor(encodedString, nil)
 	s.Require().Nil(result, desc)
 	s.Require().Equal(codeutil.ErrEmptyEncodedString, err, desc)
 }
@@ -46,51 +47,149 @@ func decodeCursor_DecodedEmptyString_ReturnErr(s *CodeUtilSuite, desc string) {
 	cursorKey := ""
 	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
 
-	fmt.Println("encodedString: ", encodedString)
-
 	// action
-	result, err := codeutil.DecodeCursor(encodedString)
+	result, err := codeutil.DecodeCursor(encodedString, nil)
 	s.Require().Nil(result, desc)
 	s.Require().Equal(codeutil.ErrEmptyEncodedString, err, desc)
 }
 
 func decodeCursor_InvalidFormatCursor_ReturnErr(s *CodeUtilSuite, desc string) {
 	// prepare encoded string
-	cursorKey := "id:123,main_category_id"
+	cursorKey := "ID:123,MainCategID"
 	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
 
 	// action
-	result, err := codeutil.DecodeCursor(encodedString)
+	result, err := codeutil.DecodeCursor(encodedString, nil)
 	s.Require().Nil(result, desc)
 	s.Require().Equal(codeutil.ErrInvalidFormatCursor, err, desc)
 }
 
+func decodeCursor_SourceFieldNotFound_ReturnErr(s *CodeUtilSuite, desc string) {
+	// prepare encoded string
+	cursorKey := "ID:123,MainCategID:456"
+	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
+
+	// prepare field source
+	fieldSource := struct {
+		ID string
+	}{}
+
+	// action
+	result, err := codeutil.DecodeCursor(encodedString, fieldSource)
+	s.Require().Nil(result, desc)
+	s.Require().Equal(codeutil.ErrFieldNotFound, err, desc)
+}
+
 func decodeCursor_ValidEncodedString_ReturnCursorMap(s *CodeUtilSuite, desc string) {
 	// prepare encoded string
-	cursorKey := "id:123,main_category_id:456"
+	cursorKey := "ID:123,MainCategID:456"
 	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
 
 	// prepare expected result
 	cursorMap := map[string]string{
-		"id":               "123",
-		"main_category_id": "456",
+		"ID":          "123",
+		"MainCategID": "456",
 	}
 
 	// action
-	result, err := codeutil.DecodeCursor(encodedString)
-	s.Require().NoError(err)
-	s.Require().Equal(cursorMap, result)
+	result, err := codeutil.DecodeCursor(encodedString, nil)
+	s.Require().NoError(err, desc)
+	s.Require().Equal(cursorMap, result, desc)
+}
+
+func decodeCursor_WithCorrectSourceField_ReturnCursorMap(s *CodeUtilSuite, desc string) {
+	// prepare encoded string
+	cursorKey := "ID:123,MainCategID:456"
+	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
+
+	// prepare field source
+	fieldSource := struct {
+		ID          string
+		MainCategID string
+	}{}
+
+	// prepare expected result
+	cursorMap := map[string]string{
+		"ID":          "123",
+		"MainCategID": "456",
+	}
+
+	// action
+	result, err := codeutil.DecodeCursor(encodedString, fieldSource)
+	s.Require().NoError(err, desc)
+	s.Require().Equal(cursorMap, result, desc)
 }
 
 func (s *CodeUtilSuite) TestEncodeCursor() {
-	cursor := map[string]string{
-		"id": "123",
+	for scenario, fn := range map[string]func(*CodeUtilSuite, string){
+		"when the field is not found, return an error":            encodeCursor_FieldNotFound_ReturnErr,
+		"when the cursor map is valid, return encoded string":     encodeCursor_ValidCursorMap_ReturnEncodedString,
+		"when the field source is correct, return encoded string": encodeCursor_WithCorrectFieldSource_ReturnEncodedString,
+	} {
+		s.Run(testutil.GetFunName(fn), func() {
+			fn(s, scenario)
+		})
 	}
 
-	encodedString := codeutil.EncodeCursor(cursor)
+}
 
-	// check
-	encodedBytes, err := base64.StdEncoding.DecodeString(encodedString)
-	s.Require().NoError(err)
-	s.Require().Equal("id:123", string(encodedBytes))
+func encodeCursor_FieldNotFound_ReturnErr(s *CodeUtilSuite, desc string) {
+	// prepare cursor map
+	cursorMap := map[string]string{
+		"ID":          "123",
+		"MainCategID": "456",
+	}
+
+	// prepare field source
+	fieldSource := struct {
+		ID string
+	}{}
+
+	// action
+	result, err := codeutil.EncodeCursor(cursorMap, fieldSource)
+	s.Require().Empty(result, desc)
+	s.Require().Equal(codeutil.ErrFieldNotFound, err, desc)
+}
+
+func encodeCursor_ValidCursorMap_ReturnEncodedString(s *CodeUtilSuite, desc string) {
+	// prepare cursor map
+	cursorMap := map[string]string{
+		"ID":          "123",
+		"MainCategID": "456",
+	}
+
+	// prepare expected result
+	cursorKey := "ID:123,MainCategID:456"
+	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
+
+	// action
+	result, err := codeutil.EncodeCursor(cursorMap, nil)
+	s.Require().NoError(err, desc)
+	s.Require().Equal(encodedString, result, desc)
+}
+
+func encodeCursor_WithCorrectFieldSource_ReturnEncodedString(s *CodeUtilSuite, desc string) {
+	// prepare cursor map
+	cursorMap := map[string]string{
+		"ID":          "123",
+		"MainCategID": "456",
+	}
+
+	// prepare field source
+	fieldSource := struct {
+		ID          string
+		MainCategID string
+	}{
+		ID:          "123",
+		MainCategID: "456new",
+	}
+
+	// prepare expected result
+	cursorKey := "ID:123,MainCategID:456new"
+	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
+
+	// action
+	result, err := codeutil.EncodeCursor(cursorMap, fieldSource)
+	s.Require().NoError(err, desc)
+	s.Require().Equal(encodedString, result, desc)
 }

--- a/pkg/codeutil/code_test.go
+++ b/pkg/codeutil/code_test.go
@@ -160,12 +160,15 @@ func encodeCursor_ValidCursorMap_ReturnEncodedString(s *CodeUtilSuite, desc stri
 
 	// prepare expected result
 	cursorKey := "ID:123,MainCategID:456"
-	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
 
 	// action
 	result, err := codeutil.EncodeCursor(cursorMap, nil)
 	s.Require().NoError(err, desc)
-	s.Require().Equal(encodedString, result, desc)
+
+	// check decoded string
+	decodedBytes, err := base64.StdEncoding.DecodeString(result)
+	s.Require().NoError(err, desc)
+	s.Require().Equal(cursorKey, string(decodedBytes), desc)
 }
 
 func encodeCursor_WithCorrectFieldSource_ReturnEncodedString(s *CodeUtilSuite, desc string) {
@@ -186,10 +189,13 @@ func encodeCursor_WithCorrectFieldSource_ReturnEncodedString(s *CodeUtilSuite, d
 
 	// prepare expected result
 	cursorKey := "ID:123,MainCategID:456new"
-	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
 
 	// action
 	result, err := codeutil.EncodeCursor(cursorMap, fieldSource)
 	s.Require().NoError(err, desc)
-	s.Require().Equal(encodedString, result, desc)
+
+	// check encoded string
+	decodedBytes, err := base64.StdEncoding.DecodeString(result)
+	s.Require().NoError(err, desc)
+	s.Require().Equal(cursorKey, string(decodedBytes), desc)
 }


### PR DESCRIPTION
- add `sourceField` to codeutil function for checking if cursor key existed in `sourceField`
- fix testing, and add more testing case