### PR TITLE
Fix: use rebust assertion

### DIFF
--- a/pkg/codeutil/code_test.go
+++ b/pkg/codeutil/code_test.go
@@ -152,10 +152,11 @@ func encodeCursor_FieldNotFound_ReturnErr(s *CodeUtilSuite, desc string) {
 	s.Require().Equal(codeutil.ErrFieldNotFound, err, desc)
 }
 
-// Because the output of the encoded string is random, we can't check the exact value
-// For example, the encoded string can be "SUQ6MTIzLE1haW5DYWdlZElEOjQ1Ng==" or "SUQ6MTIzLE1haW5DYWdlZElEOjewdwe=="
-// Same thing for the output of the decoded string, the output value is random
-// For example, the decoded string can be "ID:123,MainCategID:456" or "MainCategID:456,ID:123"
+// In the EncodeCursor function, the output is Base64 encoded string, and it's random
+// For example, the same input "ID:123,MainCategID:456" can be encoded to "SUQ6MTIzLE1haW5DYWdlZElEOjQ1Ng==" or "SUQ6MTIzLE1haW5DYWdlZElEOjewdwe==
+// So, we can't check the exact value of the encoded string
+// Also, the output of the decoded string is random too
+// For example, the encoded string can be decoded to "ID:123,MainCategID:456" or "MainCategID:456,ID:123"
 // The only way we can check is to check the number of pairs and the value of the pairs respectively (using for loop)
 func encodeCursor_ValidCursorMap_ReturnEncodedString(s *CodeUtilSuite, desc string) {
 	// prepare cursor map


### PR DESCRIPTION
- use more robust assertion

In the `EncodeCursor` function, the output is Base64 encoded string, and it's random
For example, the same input "ID:123,MainCategID:456" can be encoded to "SUQ6MTIzLE1haW5DYWdlZElEOjQ1Ng==" or "SUQ6MTIzLE1haW5DYWdlZElEOjewdwe==
So, we can't check the exact value of the encoded string
Also, the output of the decoded string is random too
For example, the encoded string can be decoded to "ID:123,MainCategID:456" or "MainCategID:456,ID:123"
The only way we can check is to check the number of pairs and the value of the pairs respectively (using for loop)
For example, we know that we use { "ID": "123", "MainCategID": "456" } as the input
So, we can check if the encoded string is as expected
By
1. Decoding the encoded string
2. Split the decoded string by ","
3. Loop through the pairs
4. Split the pair by ":"
5. Check if the key exists in the expected cursor map
6. Check if the value is equal to the value in the expected cursor map