### PR TITLE
Refactor/change next key type

### DIFF
--- a/internal/domain/transaction.go
+++ b/internal/domain/transaction.go
@@ -70,6 +70,13 @@ type Cursor struct {
 // e.g. {"date": "2021-01-01", "id": "1"}
 type DecodedNextKey map[string]string
 
+type DecodedNextKeys []DecodedNextKeyInfo
+
+type DecodedNextKeyInfo struct {
+	Field string
+	Value string
+}
+
 // GetTransOpt contains options for getting transactions
 type GetTransOpt struct {
 	Filter Filter `json:"filter"`

--- a/internal/domain/transaction.go
+++ b/internal/domain/transaction.go
@@ -66,12 +66,10 @@ type Cursor struct {
 	Size    int    `json:"size"`
 }
 
-// DecodedNextKey contains decoded next key.
-// e.g. {"date": "2021-01-01", "id": "1"}
-type DecodedNextKey map[string]string
-
+// DecodedNextKeys is a slice of DecodedNextKeyInfo
 type DecodedNextKeys []DecodedNextKeyInfo
 
+// DecodedNextKeyInfo contains field and value of next key
 type DecodedNextKeyInfo struct {
 	Field string
 	Value string

--- a/internal/handler/transaction/helper.go
+++ b/internal/handler/transaction/helper.go
@@ -66,7 +66,10 @@ func genGetTransOpt(r *http.Request) (domain.GetTransOpt, error) {
 	}
 	opt.Filter.SubCategIDs = subCategIDs
 
-	opt.Cursor.NextKey = r.URL.Query().Get("next_key")
+	nextKey := r.URL.Query().Get("next_key")
+	if nextKey != "" {
+		opt.Cursor.NextKey = nextKey
+	}
 
 	rawSize := r.URL.Query().Get("size")
 	if rawSize != "" {

--- a/internal/model/interfaces/interfaces.go
+++ b/internal/model/interfaces/interfaces.go
@@ -69,7 +69,7 @@ type TransactionModel interface {
 	Create(ctx context.Context, trans domain.CreateTransactionInput) error
 
 	// GetAll returns all transactions by user id and query option.
-	GetAll(ctx context.Context, query domain.GetTransOpt, userID int64) ([]domain.Transaction, domain.DecodedNextKey, error)
+	GetAll(ctx context.Context, query domain.GetTransOpt, userID int64) ([]domain.Transaction, domain.DecodedNextKeys, error)
 
 	// Update updates a transaction.
 	Update(ctx context.Context, trans domain.UpdateTransactionInput) error

--- a/internal/model/transaction/helper.go
+++ b/internal/model/transaction/helper.go
@@ -66,14 +66,14 @@ func getAllQStmt(opt domain.GetTransOpt, decodedNextKeys domain.DecodedNextKeys,
 	// when it's 2, it means there's sorting(sort by id and other field)
 	if len(decodedNextKeys) != 0 {
 		if len(decodedNextKeys) == 1 {
-			qStmt += fmt.Sprintf(" AND t.%s > ?", genDBFieldNames(decodedNextKeys[0].Field, t))
+			qStmt += fmt.Sprintf(" AND t.%s < ?", genDBFieldNames(decodedNextKeys[0].Field, t))
 		}
 
 		if len(decodedNextKeys) == 2 {
 			// WHERE t.Column_1 > val_1
 			// OR ( t.Column_1 = val_1 AND t.Column_2 > val_2 )
-			qStmt += fmt.Sprintf(" WHERE t.%s > ?", genDBFieldNames(decodedNextKeys[0].Field, t))
-			qStmt += fmt.Sprintf(" OR (t.%s = ? AND t.%s > ?)", genDBFieldNames(decodedNextKeys[0].Field, t), genDBFieldNames(decodedNextKeys[1].Field, t))
+			qStmt += fmt.Sprintf(" WHERE t.%s < ?", genDBFieldNames(decodedNextKeys[0].Field, t))
+			qStmt += fmt.Sprintf(" OR (t.%s = ? AND t.%s < ?)", genDBFieldNames(decodedNextKeys[0].Field, t), genDBFieldNames(decodedNextKeys[1].Field, t))
 		}
 	}
 

--- a/internal/model/transaction/helper.go
+++ b/internal/model/transaction/helper.go
@@ -164,12 +164,8 @@ func getAllArgs(opt domain.GetTransOpt, decodedNextKeys domain.DecodedNextKeys, 
 	}
 
 	if len(decodedNextKeys) != 0 {
-		if len(decodedNextKeys) == 1 {
-			args = append(args, decodedNextKeys[0].Value)
-		}
-
-		if len(decodedNextKeys) == 2 {
-			args = append(args, decodedNextKeys[0].Value, decodedNextKeys[0].Value, decodedNextKeys[1].Value)
+		for _, k := range decodedNextKeys {
+			args = append(args, k.Value)
 		}
 	}
 

--- a/internal/model/transaction/helper.go
+++ b/internal/model/transaction/helper.go
@@ -2,14 +2,13 @@ package transaction
 
 import (
 	"bytes"
-	"fmt"
 	"reflect"
 	"unicode"
 
 	"github.com/OYE0303/expense-tracker-go/internal/domain"
 )
 
-func getAllQStmt(opt domain.GetTransOpt, decodedNextKey domain.DecodedNextKey, t Transaction) string {
+func getAllQStmt(opt domain.GetTransOpt, decodedNextKeys domain.DecodedNextKeys, t Transaction) string {
 	qStmt := `SELECT t.id, t.user_id, t.type, t.price, t.note, t.date, mc.id, mc.name, mc.type, sc.id, sc.name, i.id, i.url
 						FROM transactions AS t
 						INNER JOIN main_categories AS mc 
@@ -60,12 +59,12 @@ func getAllQStmt(opt domain.GetTransOpt, decodedNextKey domain.DecodedNextKey, t
 		qStmt += ")"
 	}
 
-	if len(decodedNextKey) != 0 {
-		for key := range decodedNextKey {
-			s := fmt.Sprintf(" AND t.%s < ?", genDBFieldNames(key, t))
-			qStmt += s
-		}
-	}
+	// if len(decodedNextKey) != 0 {
+	// 	for key := range decodedNextKey {
+	// 		s := fmt.Sprintf(" AND t.%s < ?", genDBFieldNames(key, t))
+	// 		qStmt += s
+	// 	}
+	// }
 
 	if opt.Cursor.Size != 0 {
 		qStmt += " ORDER BY t.id DESC LIMIT ?"
@@ -113,7 +112,7 @@ func camelToSnake(input string) string {
 	return buf.String()
 }
 
-func getAllArgs(opt domain.GetTransOpt, decodedNextKey domain.DecodedNextKey, userID int64) []interface{} {
+func getAllArgs(opt domain.GetTransOpt, decodedNextKeys domain.DecodedNextKeys, userID int64) []interface{} {
 	var args []interface{}
 	args = append(args, userID)
 
@@ -153,11 +152,11 @@ func getAllArgs(opt domain.GetTransOpt, decodedNextKey domain.DecodedNextKey, us
 		}
 	}
 
-	if len(decodedNextKey) != 0 {
-		for _, v := range decodedNextKey {
-			args = append(args, v)
-		}
-	}
+	// if len(decodedNextKey) != 0 {
+	// 	for _, v := range decodedNextKey {
+	// 		args = append(args, v)
+	// 	}
+	// }
 
 	if opt.Cursor.Size != 0 {
 		args = append(args, opt.Cursor.Size)

--- a/internal/model/transaction/transaction.go
+++ b/internal/model/transaction/transaction.go
@@ -49,19 +49,19 @@ func (t *TransactionModel) Create(ctx context.Context, trans domain.CreateTransa
 	return nil
 }
 
-func (t *TransactionModel) GetAll(ctx context.Context, opt domain.GetTransOpt, userID int64) ([]domain.Transaction, domain.DecodedNextKey, error) {
-	var decodedNextKey domain.DecodedNextKey
+func (t *TransactionModel) GetAll(ctx context.Context, opt domain.GetTransOpt, userID int64) ([]domain.Transaction, domain.DecodedNextKeys, error) {
+	var decodedNextKeys domain.DecodedNextKeys
 	if opt.Cursor.NextKey != "" {
 		var err error
-		decodedNextKey, err = codeutil.DecodeCursor(opt.Cursor.NextKey, Transaction{})
+		decodedNextKeys, err = codeutil.DecodeCursor(opt.Cursor.NextKey, Transaction{})
 		if err != nil {
 			logger.Error("codeutil.DecodeCursor failed", "package", PackageName, "err", err)
 			return nil, nil, err
 		}
 	}
 
-	qStmt := getAllQStmt(opt, decodedNextKey, Transaction{})
-	args := getAllArgs(opt, decodedNextKey, userID)
+	qStmt := getAllQStmt(opt, decodedNextKeys, Transaction{})
+	args := getAllArgs(opt, decodedNextKeys, userID)
 
 	rows, err := t.DB.QueryContext(ctx, qStmt, args...)
 	if err != nil {
@@ -86,7 +86,7 @@ func (t *TransactionModel) GetAll(ctx context.Context, opt domain.GetTransOpt, u
 	}
 	defer rows.Close()
 
-	return transactions, decodedNextKey, nil
+	return transactions, decodedNextKeys, nil
 }
 
 func (t *TransactionModel) Update(ctx context.Context, trans domain.UpdateTransactionInput) error {

--- a/internal/model/transaction/transaction.go
+++ b/internal/model/transaction/transaction.go
@@ -53,7 +53,7 @@ func (t *TransactionModel) GetAll(ctx context.Context, opt domain.GetTransOpt, u
 	var decodedNextKeys domain.DecodedNextKeys
 	if opt.Cursor.NextKey != "" {
 		var err error
-		decodedNextKeys, err = codeutil.DecodeCursor(opt.Cursor.NextKey, Transaction{})
+		decodedNextKeys, err = codeutil.DecodeNextKeys(opt.Cursor.NextKey, Transaction{})
 		if err != nil {
 			logger.Error("codeutil.DecodeCursor failed", "package", PackageName, "err", err)
 			return nil, nil, err

--- a/internal/model/transaction/transaction_test.go
+++ b/internal/model/transaction/transaction_test.go
@@ -3,14 +3,12 @@ package transaction_test
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/OYE0303/expense-tracker-go/internal/domain"
 	"github.com/OYE0303/expense-tracker-go/internal/model/maincateg"
 	"github.com/OYE0303/expense-tracker-go/internal/model/transaction"
-	"github.com/OYE0303/expense-tracker-go/pkg/codeutil"
 	"github.com/OYE0303/expense-tracker-go/pkg/dockerutil"
 	"github.com/OYE0303/expense-tracker-go/pkg/logger"
 	"github.com/OYE0303/expense-tracker-go/pkg/testutil"
@@ -133,7 +131,7 @@ func (s *TransactionSuite) TestGetAll() {
 		"when query max price, return data less than max price":          getAll_QueryMaxPrice_ReturnDataLessThanMinPrice,
 		"when query main category id, return data with main category id": getAll_QueryMainCategID_ReturnDataWithMainCategID,
 		"when query sub category id, return data with sub category id":   getAll_QuerySubCategID_ReturnDataWithSubCategID,
-		"when with next key cursor, return data after cursor key":        getAll_WithNextKeyCursor_ReturnDataAfterCursorKey,
+		// "when with next key cursor, return data after cursor key":        getAll_WithNextKeyCursor_ReturnDataAfterCursorKey,
 	} {
 		s.Run(testutil.GetFunName(fn), func() {
 			s.SetupTest()
@@ -408,36 +406,36 @@ func getAll_QuerySubCategID_ReturnDataWithSubCategID(s *TransactionSuite, desc s
 	s.Require().Empty(decodedNextKey, desc)
 }
 
-func getAll_WithNextKeyCursor_ReturnDataAfterCursorKey(s *TransactionSuite, desc string) {
-	transactionList, user, mainList, subList, iconList, err := s.f.InsertTransactionsWithOneUser(8)
-	s.Require().NoError(err, desc)
+// func getAll_WithNextKeyCursor_ReturnDataAfterCursorKey(s *TransactionSuite, desc string) {
+// 	transactionList, user, mainList, subList, iconList, err := s.f.InsertTransactionsWithOneUser(8)
+// 	s.Require().NoError(err, desc)
 
-	// prepare encodedNextKey
-	// Note that the order of the transactionList is based on the ID(default), and it's descending
-	// which means that this encodedNextKey will query the data from the 5th index
-	encodedNextKey, err := codeutil.EncodeCursor(domain.DecodedNextKey{"ID": "1"}, transactionList[6])
-	s.Require().NoError(err, desc)
+// 	// prepare encodedNextKey
+// 	// Note that the order of the transactionList is based on the ID(default), and it's descending
+// 	// which means that this encodedNextKey will query the data from the 5th index
+// 	encodedNextKey, err := codeutil.EncodeCursor(domain.DecodedNextKey{"ID": "1"}, transactionList[6])
+// 	s.Require().NoError(err, desc)
 
-	// prepare more users
-	_, _, _, _, _, err = s.f.InsertTransactionsWithOneUser(1)
-	s.Require().NoError(err, desc)
-	_, _, _, _, _, err = s.f.InsertTransactionsWithOneUser(1)
-	s.Require().NoError(err, desc)
+// 	// prepare more users
+// 	_, _, _, _, _, err = s.f.InsertTransactionsWithOneUser(1)
+// 	s.Require().NoError(err, desc)
+// 	_, _, _, _, _, err = s.f.InsertTransactionsWithOneUser(1)
+// 	s.Require().NoError(err, desc)
 
-	expResult := transaction.GetAll_GenExpResult(transactionList, user, mainList, subList, iconList, 5, 4, 3)
+// 	expResult := transaction.GetAll_GenExpResult(transactionList, user, mainList, subList, iconList, 5, 4, 3)
 
-	opt := domain.GetTransOpt{
-		Cursor: domain.Cursor{
-			NextKey: encodedNextKey,
-			Size:    3,
-		},
-	}
-	trans, deencodedNextKey, err := s.transactionModel.GetAll(mockCtx, opt, user.ID)
-	s.Require().NoError(err, desc)
-	s.Require().Equal(expResult, trans, desc)
-	decodedNextKeyID := transactionList[6].ID
-	s.Require().Equal(domain.DecodedNextKey{"ID": fmt.Sprint(decodedNextKeyID)}, deencodedNextKey, desc)
-}
+// 	opt := domain.GetTransOpt{
+// 		Cursor: domain.Cursor{
+// 			NextKey: encodedNextKey,
+// 			Size:    3,
+// 		},
+// 	}
+// 	trans, deencodedNextKey, err := s.transactionModel.GetAll(mockCtx, opt, user.ID)
+// 	s.Require().NoError(err, desc)
+// 	s.Require().Equal(expResult, trans, desc)
+// 	decodedNextKeyID := transactionList[6].ID
+// 	s.Require().Equal(domain.DecodedNextKey{"ID": fmt.Sprint(decodedNextKeyID)}, deencodedNextKey, desc)
+// }
 
 func (s *TransactionSuite) TestUpdate() {
 	for scenario, fn := range map[string]func(s *TransactionSuite, desc string){

--- a/internal/model/transaction/transaction_test.go
+++ b/internal/model/transaction/transaction_test.go
@@ -3,12 +3,14 @@ package transaction_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/OYE0303/expense-tracker-go/internal/domain"
 	"github.com/OYE0303/expense-tracker-go/internal/model/maincateg"
 	"github.com/OYE0303/expense-tracker-go/internal/model/transaction"
+	"github.com/OYE0303/expense-tracker-go/pkg/codeutil"
 	"github.com/OYE0303/expense-tracker-go/pkg/dockerutil"
 	"github.com/OYE0303/expense-tracker-go/pkg/logger"
 	"github.com/OYE0303/expense-tracker-go/pkg/testutil"
@@ -131,7 +133,7 @@ func (s *TransactionSuite) TestGetAll() {
 		"when query max price, return data less than max price":          getAll_QueryMaxPrice_ReturnDataLessThanMinPrice,
 		"when query main category id, return data with main category id": getAll_QueryMainCategID_ReturnDataWithMainCategID,
 		"when query sub category id, return data with sub category id":   getAll_QuerySubCategID_ReturnDataWithSubCategID,
-		// "when with next key cursor, return data after cursor key":        getAll_WithNextKeyCursor_ReturnDataAfterCursorKey,
+		"when with next key cursor, return data after cursor key":        getAll_WithNextKeyCursor_ReturnDataAfterCursorKey,
 	} {
 		s.Run(testutil.GetFunName(fn), func() {
 			s.SetupTest()
@@ -406,36 +408,36 @@ func getAll_QuerySubCategID_ReturnDataWithSubCategID(s *TransactionSuite, desc s
 	s.Require().Empty(decodedNextKey, desc)
 }
 
-// func getAll_WithNextKeyCursor_ReturnDataAfterCursorKey(s *TransactionSuite, desc string) {
-// 	transactionList, user, mainList, subList, iconList, err := s.f.InsertTransactionsWithOneUser(8)
-// 	s.Require().NoError(err, desc)
+func getAll_WithNextKeyCursor_ReturnDataAfterCursorKey(s *TransactionSuite, desc string) {
+	transactionList, user, mainList, subList, iconList, err := s.f.InsertTransactionsWithOneUser(8)
+	s.Require().NoError(err, desc)
 
-// 	// prepare encodedNextKey
-// 	// Note that the order of the transactionList is based on the ID(default), and it's descending
-// 	// which means that this encodedNextKey will query the data from the 5th index
-// 	encodedNextKey, err := codeutil.EncodeCursor(domain.DecodedNextKey{"ID": "1"}, transactionList[6])
-// 	s.Require().NoError(err, desc)
+	// prepare encodedNextKey
+	// Note that the order of the transactionList is based on the ID(default), and it's descending
+	// which means that this encodedNextKey will query the data from the 5th index
+	encodedNextKey, err := codeutil.EncodeNextKeys(domain.DecodedNextKeys{{Field: "ID", Value: "1"}}, transactionList[6])
+	s.Require().NoError(err, desc)
 
-// 	// prepare more users
-// 	_, _, _, _, _, err = s.f.InsertTransactionsWithOneUser(1)
-// 	s.Require().NoError(err, desc)
-// 	_, _, _, _, _, err = s.f.InsertTransactionsWithOneUser(1)
-// 	s.Require().NoError(err, desc)
+	// prepare more users
+	_, _, _, _, _, err = s.f.InsertTransactionsWithOneUser(1)
+	s.Require().NoError(err, desc)
+	_, _, _, _, _, err = s.f.InsertTransactionsWithOneUser(1)
+	s.Require().NoError(err, desc)
 
-// 	expResult := transaction.GetAll_GenExpResult(transactionList, user, mainList, subList, iconList, 5, 4, 3)
+	expResult := transaction.GetAll_GenExpResult(transactionList, user, mainList, subList, iconList, 5, 4, 3)
 
-// 	opt := domain.GetTransOpt{
-// 		Cursor: domain.Cursor{
-// 			NextKey: encodedNextKey,
-// 			Size:    3,
-// 		},
-// 	}
-// 	trans, deencodedNextKey, err := s.transactionModel.GetAll(mockCtx, opt, user.ID)
-// 	s.Require().NoError(err, desc)
-// 	s.Require().Equal(expResult, trans, desc)
-// 	decodedNextKeyID := transactionList[6].ID
-// 	s.Require().Equal(domain.DecodedNextKey{"ID": fmt.Sprint(decodedNextKeyID)}, deencodedNextKey, desc)
-// }
+	opt := domain.GetTransOpt{
+		Cursor: domain.Cursor{
+			NextKey: encodedNextKey,
+			Size:    3,
+		},
+	}
+	trans, deencodedNextKey, err := s.transactionModel.GetAll(mockCtx, opt, user.ID)
+	s.Require().NoError(err, desc)
+	s.Require().Equal(expResult, trans, desc)
+	decodedNextKeyID := transactionList[6].ID
+	s.Require().Equal(domain.DecodedNextKey{"ID": fmt.Sprint(decodedNextKeyID)}, deencodedNextKey, desc)
+}
 
 func (s *TransactionSuite) TestUpdate() {
 	for scenario, fn := range map[string]func(s *TransactionSuite, desc string){

--- a/internal/model/transaction/transaction_test.go
+++ b/internal/model/transaction/transaction_test.go
@@ -436,7 +436,7 @@ func getAll_WithNextKeyCursor_ReturnDataAfterCursorKey(s *TransactionSuite, desc
 	s.Require().NoError(err, desc)
 	s.Require().Equal(expResult, trans, desc)
 	decodedNextKeyID := transactionList[6].ID
-	s.Require().Equal(domain.DecodedNextKey{"ID": fmt.Sprint(decodedNextKeyID)}, deencodedNextKey, desc)
+	s.Require().Equal(domain.DecodedNextKeys{{Field: "ID", Value: fmt.Sprint(decodedNextKeyID)}}, deencodedNextKey, desc)
 }
 
 func (s *TransactionSuite) TestUpdate() {

--- a/internal/usecase/transaction/transaction.go
+++ b/internal/usecase/transaction/transaction.go
@@ -73,7 +73,7 @@ func (t *TransactionUC) GetAll(ctx context.Context, opt domain.GetTransOpt, user
 	}
 
 	var cursor domain.Cursor
-	if len(trans) == opt.Cursor.Size {
+	if opt.Cursor.Size != 0 && len(trans) == opt.Cursor.Size {
 		cursor.Size = opt.Cursor.Size
 
 		// if it's the first page, we need to initialize the nextKey

--- a/internal/usecase/transaction/transaction.go
+++ b/internal/usecase/transaction/transaction.go
@@ -84,7 +84,7 @@ func (t *TransactionUC) GetAll(ctx context.Context, opt domain.GetTransOpt, user
 		// }
 
 		// encode the nextKey to string
-		encodedNextKey, err := codeutil.EncodeCursor(decodedNextKeys, trans[len(trans)-1])
+		encodedNextKey, err := codeutil.EncodeNextKeys(decodedNextKeys, trans[len(trans)-1])
 		if err != nil {
 			return nil, domain.Cursor{}, err
 		}

--- a/internal/usecase/transaction/transaction.go
+++ b/internal/usecase/transaction/transaction.go
@@ -67,7 +67,7 @@ func (t *TransactionUC) Create(ctx context.Context, trans domain.CreateTransacti
 }
 
 func (t *TransactionUC) GetAll(ctx context.Context, opt domain.GetTransOpt, user domain.User) ([]domain.Transaction, domain.Cursor, error) {
-	trans, decodedNextKey, err := t.Transaction.GetAll(ctx, opt, user.ID)
+	trans, decodedNextKeys, err := t.Transaction.GetAll(ctx, opt, user.ID)
 	if err != nil {
 		return nil, domain.Cursor{}, err
 	}
@@ -76,15 +76,15 @@ func (t *TransactionUC) GetAll(ctx context.Context, opt domain.GetTransOpt, user
 	if len(trans) == opt.Cursor.Size {
 		cursor.Size = opt.Cursor.Size
 
-		// if it's the first page, we need to initialize the nextKey
-		if opt.Cursor.NextKey == "" {
-			decodedNextKey = domain.DecodedNextKey{
-				"ID": "0",
-			}
-		}
+		// // if it's the first page, we need to initialize the nextKey
+		// if opt.Cursor.NextKey == "" {
+		// 	decodedNextKeys = domain.DecodedNextKey{
+		// 		"ID": "0",
+		// 	}
+		// }
 
 		// encode the nextKey to string
-		encodedNextKey, err := codeutil.EncodeCursor(decodedNextKey, trans[len(trans)-1])
+		encodedNextKey, err := codeutil.EncodeCursor(decodedNextKeys, trans[len(trans)-1])
 		if err != nil {
 			return nil, domain.Cursor{}, err
 		}

--- a/internal/usecase/transaction/transaction.go
+++ b/internal/usecase/transaction/transaction.go
@@ -76,12 +76,12 @@ func (t *TransactionUC) GetAll(ctx context.Context, opt domain.GetTransOpt, user
 	if len(trans) == opt.Cursor.Size {
 		cursor.Size = opt.Cursor.Size
 
-		// // if it's the first page, we need to initialize the nextKey
-		// if opt.Cursor.NextKey == "" {
-		// 	decodedNextKeys = domain.DecodedNextKey{
-		// 		"ID": "0",
-		// 	}
-		// }
+		// if it's the first page, we need to initialize the nextKey
+		if opt.Cursor.NextKey == "" {
+			decodedNextKeys = domain.DecodedNextKeys{
+				{Field: "ID"},
+			}
+		}
 
 		// encode the nextKey to string
 		encodedNextKey, err := codeutil.EncodeNextKeys(decodedNextKeys, trans[len(trans)-1])

--- a/internal/usecase/transaction/transaction_test.go
+++ b/internal/usecase/transaction/transaction_test.go
@@ -66,13 +66,13 @@ func (s *TransactionSuite) TestGetAll() {
 }
 
 func getAll_NoError_ReturnTransactions(s *TransactionSuite, desc string) {
-	mockDecodedNextKey := domain.DecodedNextKey{}
+	mockDecodedNextKeys := domain.DecodedNextKeys{}
 	mockOpt := domain.GetTransOpt{}
 	mockUser := domain.User{ID: 1}
 	mockTrans := []domain.Transaction{{ID: 1, UserID: 1}}
 
 	s.mockTransaction.On("GetAll", mockCtx, mockOpt, int64(1)).
-		Return(mockTrans, mockDecodedNextKey, nil).Once()
+		Return(mockTrans, mockDecodedNextKeys, nil).Once()
 
 	result, cursor, err := s.transactionUC.GetAll(mockCtx, mockOpt, mockUser)
 	s.Require().NoError(err, desc)
@@ -81,12 +81,12 @@ func getAll_NoError_ReturnTransactions(s *TransactionSuite, desc string) {
 }
 
 func getAll_GetTransFail_ReturnError(s *TransactionSuite, desc string) {
-	mockDecodedNextKey := domain.DecodedNextKey{}
+	mockDecodedNextKeys := domain.DecodedNextKeys{}
 	mockOpt := domain.GetTransOpt{}
 	mockUser := domain.User{ID: 1}
 
 	s.mockTransaction.On("GetAll", mockCtx, mockOpt, int64(1)).
-		Return(nil, mockDecodedNextKey, errors.New("error")).Once()
+		Return(nil, mockDecodedNextKeys, errors.New("error")).Once()
 
 	result, cursor, err := s.transactionUC.GetAll(mockCtx, mockOpt, mockUser)
 	s.Require().Equal(errors.New("error"), err, desc)
@@ -95,13 +95,13 @@ func getAll_GetTransFail_ReturnError(s *TransactionSuite, desc string) {
 }
 
 func getAll_InitPageWithSize_ReturnCorrectCursor(s *TransactionSuite, desc string) {
-	mockDecodedNextKey := domain.DecodedNextKey{}
+	mockDecodedNextKeys := domain.DecodedNextKeys{}
 	mockOpt := domain.GetTransOpt{Cursor: domain.Cursor{Size: 1}}
 	mockUser := domain.User{ID: 1}
 	mockTrans := []domain.Transaction{{ID: 1, UserID: 1}}
 
 	s.mockTransaction.On("GetAll", mockCtx, mockOpt, int64(1)).
-		Return(mockTrans, mockDecodedNextKey, nil).Once()
+		Return(mockTrans, mockDecodedNextKeys, nil).Once()
 
 	result, cursor, err := s.transactionUC.GetAll(mockCtx, mockOpt, mockUser)
 	s.Require().NoError(err, desc)
@@ -115,15 +115,13 @@ func getAll_InitPageWithSize_ReturnCorrectCursor(s *TransactionSuite, desc strin
 }
 
 func getAll_WithDecodedNextKey_ReturnCorrectCursor(s *TransactionSuite, desc string) {
-	mockDecodedNextKey := domain.DecodedNextKey{
-		"ID": "1",
-	}
+	mockDecodedNextKeys := domain.DecodedNextKeys{{Field: "ID", Value: "1"}}
 	mockOpt := domain.GetTransOpt{Cursor: domain.Cursor{Size: 1, NextKey: "eyJJRCI6IjEifQ=="}}
 	mockUser := domain.User{ID: 1}
 	mockTrans := []domain.Transaction{{ID: 2, UserID: 1}}
 
 	s.mockTransaction.On("GetAll", mockCtx, mockOpt, int64(1)).
-		Return(mockTrans, mockDecodedNextKey, nil).Once()
+		Return(mockTrans, mockDecodedNextKeys, nil).Once()
 
 	result, cursor, err := s.transactionUC.GetAll(mockCtx, mockOpt, mockUser)
 	s.Require().NoError(err, desc)
@@ -133,7 +131,7 @@ func getAll_WithDecodedNextKey_ReturnCorrectCursor(s *TransactionSuite, desc str
 	// check encoded next key
 	encodedNextKey, err := codeutil.DecodeNextKeys(cursor.NextKey, nil)
 	s.Require().NoError(err, desc)
-	s.Require().Equal(domain.DecodedNextKey{"ID": "2"}, encodedNextKey, desc)
+	s.Require().Equal(domain.DecodedNextKeys{{Field: "ID", Value: "2"}}, encodedNextKey, desc)
 }
 
 func (s *TransactionSuite) TestUpdate() {

--- a/internal/usecase/transaction/transaction_test.go
+++ b/internal/usecase/transaction/transaction_test.go
@@ -56,6 +56,7 @@ func (s *TransactionSuite) TestGetAll() {
 		"when get transactions fail, return error":                                  getAll_GetTransFail_ReturnError,
 		"when it's the first page with size, return correct cursor":                 getAll_InitPageWithSize_ReturnCorrectCursor,
 		"when it's not the first page with decoded next key, return correct cursor": getAll_WithDecodedNextKey_ReturnCorrectCursor,
+		"when size is empty value, return no cursor":                                getAll_SizeIsEmptyValue_ReturnNoCursor,
 	} {
 		s.Run(testutil.GetFunName(fn), func() {
 			s.SetupTest()
@@ -132,6 +133,21 @@ func getAll_WithDecodedNextKey_ReturnCorrectCursor(s *TransactionSuite, desc str
 	encodedNextKey, err := codeutil.DecodeNextKeys(cursor.NextKey, nil)
 	s.Require().NoError(err, desc)
 	s.Require().Equal(domain.DecodedNextKeys{{Field: "ID", Value: "2"}}, encodedNextKey, desc)
+}
+
+func getAll_SizeIsEmptyValue_ReturnNoCursor(s *TransactionSuite, desc string) {
+	mockDecodedNextKeys := domain.DecodedNextKeys{}
+	mockOpt := domain.GetTransOpt{}
+	mockUser := domain.User{ID: 1}
+	mockTrans := []domain.Transaction{}
+
+	s.mockTransaction.On("GetAll", mockCtx, mockOpt, int64(1)).
+		Return(mockTrans, mockDecodedNextKeys, nil).Once()
+
+	result, cursor, err := s.transactionUC.GetAll(mockCtx, mockOpt, mockUser)
+	s.Require().NoError(err, desc)
+	s.Require().Equal(mockTrans, result, desc)
+	s.Require().Equal(domain.Cursor{}, cursor, desc)
 }
 
 func (s *TransactionSuite) TestUpdate() {

--- a/internal/usecase/transaction/transaction_test.go
+++ b/internal/usecase/transaction/transaction_test.go
@@ -109,7 +109,7 @@ func getAll_InitPageWithSize_ReturnCorrectCursor(s *TransactionSuite, desc strin
 	s.Require().Equal(1, cursor.Size, desc)
 
 	// check decoded next key
-	encodedNextKey, err := codeutil.DecodeCursor(cursor.NextKey, nil)
+	encodedNextKey, err := codeutil.DecodeNextKeys(cursor.NextKey, nil)
 	s.Require().NoError(err, desc)
 	s.Require().Equal(domain.DecodedNextKey{"ID": "1"}, encodedNextKey, desc)
 }
@@ -131,7 +131,7 @@ func getAll_WithDecodedNextKey_ReturnCorrectCursor(s *TransactionSuite, desc str
 	s.Require().Equal(1, cursor.Size, desc)
 
 	// check encoded next key
-	encodedNextKey, err := codeutil.DecodeCursor(cursor.NextKey, nil)
+	encodedNextKey, err := codeutil.DecodeNextKeys(cursor.NextKey, nil)
 	s.Require().NoError(err, desc)
 	s.Require().Equal(domain.DecodedNextKey{"ID": "2"}, encodedNextKey, desc)
 }

--- a/internal/usecase/transaction/transaction_test.go
+++ b/internal/usecase/transaction/transaction_test.go
@@ -111,7 +111,7 @@ func getAll_InitPageWithSize_ReturnCorrectCursor(s *TransactionSuite, desc strin
 	// check decoded next key
 	encodedNextKey, err := codeutil.DecodeNextKeys(cursor.NextKey, nil)
 	s.Require().NoError(err, desc)
-	s.Require().Equal(domain.DecodedNextKey{"ID": "1"}, encodedNextKey, desc)
+	s.Require().Equal(domain.DecodedNextKeys{{Field: "ID", Value: "1"}}, encodedNextKey, desc)
 }
 
 func getAll_WithDecodedNextKey_ReturnCorrectCursor(s *TransactionSuite, desc string) {

--- a/mocks/TransactionModel.go
+++ b/mocks/TransactionModel.go
@@ -80,7 +80,7 @@ func (_m *TransactionModel) GetAccInfo(ctx context.Context, query domain.GetAccI
 }
 
 // GetAll provides a mock function with given fields: ctx, query, userID
-func (_m *TransactionModel) GetAll(ctx context.Context, query domain.GetTransOpt, userID int64) ([]domain.Transaction, domain.DecodedNextKey, error) {
+func (_m *TransactionModel) GetAll(ctx context.Context, query domain.GetTransOpt, userID int64) ([]domain.Transaction, domain.DecodedNextKeys, error) {
 	ret := _m.Called(ctx, query, userID)
 
 	if len(ret) == 0 {
@@ -88,9 +88,9 @@ func (_m *TransactionModel) GetAll(ctx context.Context, query domain.GetTransOpt
 	}
 
 	var r0 []domain.Transaction
-	var r1 domain.DecodedNextKey
+	var r1 domain.DecodedNextKeys
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, domain.GetTransOpt, int64) ([]domain.Transaction, domain.DecodedNextKey, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, domain.GetTransOpt, int64) ([]domain.Transaction, domain.DecodedNextKeys, error)); ok {
 		return rf(ctx, query, userID)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, domain.GetTransOpt, int64) []domain.Transaction); ok {
@@ -101,11 +101,11 @@ func (_m *TransactionModel) GetAll(ctx context.Context, query domain.GetTransOpt
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, domain.GetTransOpt, int64) domain.DecodedNextKey); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, domain.GetTransOpt, int64) domain.DecodedNextKeys); ok {
 		r1 = rf(ctx, query, userID)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(domain.DecodedNextKey)
+			r1 = ret.Get(1).(domain.DecodedNextKeys)
 		}
 	}
 

--- a/pkg/codeutil/code.go
+++ b/pkg/codeutil/code.go
@@ -26,9 +26,9 @@ var (
 	ErrFieldNotFound = errors.New("field not found")
 )
 
-// DecodeCursor decodes cursor from encoded string to map
-// fieldSource is used to check if the field exists in ecoded string
-func DecodeCursor(encodedString string, fieldSource interface{}) (domain.DecodedNextKeys, error) {
+// DecodeNextKeys decodes encoded next key string to decoded next keys.
+// fieldSource is used to check if the field exists in the fieldSource
+func DecodeNextKeys(encodedString string, fieldSource interface{}) (domain.DecodedNextKeys, error) {
 	if encodedString == "" {
 		return nil, ErrEmptyEncodedString
 	}
@@ -71,9 +71,9 @@ func DecodeCursor(encodedString string, fieldSource interface{}) (domain.Decoded
 	return result, nil
 }
 
-// EncodeCursor encodes cursor from map to encoded string
-// fieldSource is used to get the field value from the source
-func EncodeCursor(decodedNextKeys domain.DecodedNextKeys, fieldSource interface{}) (string, error) {
+// EncodeNextKeys encodes decoded next keys to encoded string.
+// fieldSource is used to get the latest field value from the source
+func EncodeNextKeys(decodedNextKeys domain.DecodedNextKeys, fieldSource interface{}) (string, error) {
 	var pairs string
 
 	for _, key := range decodedNextKeys {

--- a/pkg/codeutil/code.go
+++ b/pkg/codeutil/code.go
@@ -28,7 +28,7 @@ var (
 
 // DecodeCursor decodes cursor from encoded string to map
 // fieldSource is used to check if the field exists in ecoded string
-func DecodeCursor(encodedString string, fieldSource interface{}) (domain.DecodedNextKey, error) {
+func DecodeCursor(encodedString string, fieldSource interface{}) (domain.DecodedNextKeys, error) {
 	if encodedString == "" {
 		return nil, ErrEmptyEncodedString
 	}
@@ -45,7 +45,7 @@ func DecodeCursor(encodedString string, fieldSource interface{}) (domain.Decoded
 		return nil, ErrInvalidFormatCursor
 	}
 
-	result := domain.DecodedNextKey{}
+	result := domain.DecodedNextKeys{}
 	for _, pair := range pairs {
 		keyValue := strings.Split(pair, ":")
 		if len(keyValue) != 2 {
@@ -62,7 +62,10 @@ func DecodeCursor(encodedString string, fieldSource interface{}) (domain.Decoded
 			}
 		}
 
-		result[key] = value
+		result = append(result, domain.DecodedNextKeyInfo{
+			Field: key,
+			Value: value,
+		})
 	}
 
 	return result, nil
@@ -70,24 +73,29 @@ func DecodeCursor(encodedString string, fieldSource interface{}) (domain.Decoded
 
 // EncodeCursor encodes cursor from map to encoded string
 // fieldSource is used to get the field value from the source
-func EncodeCursor(decodedNextKey domain.DecodedNextKey, fieldSource interface{}) (string, error) {
-	pairs := make([]string, 0, len(decodedNextKey))
-	for key, value := range decodedNextKey {
+func EncodeCursor(decodedNextKeys domain.DecodedNextKeys, fieldSource interface{}) (string, error) {
+	var pairs string
+
+	for _, key := range decodedNextKeys {
 		if fieldSource == nil {
-			pairs = append(pairs, key+":"+value)
+			pairs += key.Field + ":" + key.Value + ","
 			continue
 		}
 
 		// note that we have to use the fieldSource to get the value
 		// and set it to encoded string when encoding
-		v, ok := getFieldValue(fieldSource, key)
+		v, ok := getFieldValue(fieldSource, key.Field)
 		if !ok {
 			return "", ErrFieldNotFound
 		}
-		pairs = append(pairs, key+":"+cvtToString(v))
+
+		pairs += key.Field + ":" + cvtToString(v) + ","
 	}
 
-	encodedString := base64.StdEncoding.EncodeToString([]byte(strings.Join(pairs, ",")))
+	// remove the last comma
+	pairs = pairs[:len(pairs)-1]
+
+	encodedString := base64.StdEncoding.EncodeToString([]byte(pairs))
 	return encodedString, nil
 }
 

--- a/pkg/codeutil/code_test.go
+++ b/pkg/codeutil/code_test.go
@@ -152,12 +152,6 @@ func encodeNextKeys_FieldNotFound_ReturnErr(s *CodeUtilSuite, desc string) {
 	s.Require().Equal(codeutil.ErrFieldNotFound, err, desc)
 }
 
-// In the EncodeCursor function, the output is Base64 encoded string, and it's random
-// For example, the same input "ID:123,MainCategID:456" can be encoded to "SUQ6MTIzLE1haW5DYWdlZElEOjQ1Ng==" or "SUQ6MTIzLE1haW5DYWdlZElEOjewdwe==
-// So, we can't check the exact value of the encoded string
-// Also, the output of the decoded string is random too
-// For example, the encoded string can be decoded to "ID:123,MainCategID:456" or "MainCategID:456,ID:123"
-// The only way we can check is to check the number of pairs and the value of the pairs respectively (using for loop)
 func encodeNextKeys_ValidCursorMap_ReturnEncodedString(s *CodeUtilSuite, desc string) {
 	// prepare next keys
 	nextKeys := domain.DecodedNextKeys{

--- a/pkg/codeutil/code_test.go
+++ b/pkg/codeutil/code_test.go
@@ -18,14 +18,14 @@ func TestEncodeSuite(t *testing.T) {
 	suite.Run(t, new(CodeUtilSuite))
 }
 
-func (s *CodeUtilSuite) TestDecodeCursor() {
+func (s *CodeUtilSuite) TestDecodeNextKeys() {
 	for scenario, fn := range map[string]func(*CodeUtilSuite, string){
-		"when the encoded string is empty, return an error":   decodeCursor_EncodedEmptyString_ReturnErr,
-		"when the decoded string is empty, return an error":   decodeCursor_DecodedEmptyString_ReturnErr,
-		"when the cursor format is invalid, return an error":  decodeCursor_InvalidFormatCursor_ReturnErr,
-		"when the source field is not found, return an error": decodeCursor_SourceFieldNotFound_ReturnErr,
-		"when the encoded string is valid, return cursor map": decodeCursor_ValidEncodedString_ReturnCursorMap,
-		"when the source field is correct, return cursor map": decodeCursor_WithCorrectSourceField_ReturnCursorMap,
+		"when the encoded string is empty, return an error":   decodeNextKeys_EncodedEmptyString_ReturnErr,
+		"when the decoded string is empty, return an error":   decodeNextKeys_DecodedEmptyString_ReturnErr,
+		"when the cursor format is invalid, return an error":  decodeNextKeys_InvalidFormatCursor_ReturnErr,
+		"when the source field is not found, return an error": decodeNextKeys_SourceFieldNotFound_ReturnErr,
+		"when the encoded string is valid, return cursor map": decodeNextKeys_ValidEncodedString_ReturnCursorMap,
+		"when the source field is correct, return cursor map": decodeNextKeys_WithCorrectSourceField_ReturnCursorMap,
 	} {
 		s.Run(testutil.GetFunName(fn), func() {
 			fn(s, scenario)
@@ -33,39 +33,39 @@ func (s *CodeUtilSuite) TestDecodeCursor() {
 	}
 }
 
-func decodeCursor_EncodedEmptyString_ReturnErr(s *CodeUtilSuite, desc string) {
+func decodeNextKeys_EncodedEmptyString_ReturnErr(s *CodeUtilSuite, desc string) {
 	// prepare encoded string
 	encodedString := ""
 
 	// action
-	result, err := codeutil.DecodeCursor(encodedString, nil)
+	result, err := codeutil.DecodeNextKeys(encodedString, nil)
 	s.Require().Nil(result, desc)
 	s.Require().Equal(codeutil.ErrEmptyEncodedString, err, desc)
 }
 
-func decodeCursor_DecodedEmptyString_ReturnErr(s *CodeUtilSuite, desc string) {
+func decodeNextKeys_DecodedEmptyString_ReturnErr(s *CodeUtilSuite, desc string) {
 	// prepare encoded string
 	cursorKey := ""
 	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
 
 	// action
-	result, err := codeutil.DecodeCursor(encodedString, nil)
+	result, err := codeutil.DecodeNextKeys(encodedString, nil)
 	s.Require().Nil(result, desc)
 	s.Require().Equal(codeutil.ErrEmptyEncodedString, err, desc)
 }
 
-func decodeCursor_InvalidFormatCursor_ReturnErr(s *CodeUtilSuite, desc string) {
+func decodeNextKeys_InvalidFormatCursor_ReturnErr(s *CodeUtilSuite, desc string) {
 	// prepare encoded string
 	cursorKey := "ID:123,MainCategID"
 	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
 
 	// action
-	result, err := codeutil.DecodeCursor(encodedString, nil)
+	result, err := codeutil.DecodeNextKeys(encodedString, nil)
 	s.Require().Nil(result, desc)
 	s.Require().Equal(codeutil.ErrInvalidFormatCursor, err, desc)
 }
 
-func decodeCursor_SourceFieldNotFound_ReturnErr(s *CodeUtilSuite, desc string) {
+func decodeNextKeys_SourceFieldNotFound_ReturnErr(s *CodeUtilSuite, desc string) {
 	// prepare encoded string
 	cursorKey := "ID:123,MainCategID:456"
 	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
@@ -76,12 +76,12 @@ func decodeCursor_SourceFieldNotFound_ReturnErr(s *CodeUtilSuite, desc string) {
 	}{}
 
 	// action
-	result, err := codeutil.DecodeCursor(encodedString, fieldSource)
+	result, err := codeutil.DecodeNextKeys(encodedString, fieldSource)
 	s.Require().Nil(result, desc)
 	s.Require().Equal(codeutil.ErrFieldNotFound, err, desc)
 }
 
-func decodeCursor_ValidEncodedString_ReturnCursorMap(s *CodeUtilSuite, desc string) {
+func decodeNextKeys_ValidEncodedString_ReturnCursorMap(s *CodeUtilSuite, desc string) {
 	// prepare encoded string
 	cursorKey := "MainCategID:456,ID:123"
 	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
@@ -93,12 +93,12 @@ func decodeCursor_ValidEncodedString_ReturnCursorMap(s *CodeUtilSuite, desc stri
 	}
 
 	// action
-	result, err := codeutil.DecodeCursor(encodedString, nil)
+	result, err := codeutil.DecodeNextKeys(encodedString, nil)
 	s.Require().NoError(err, desc)
 	s.Require().Equal(cursorMap, result, desc)
 }
 
-func decodeCursor_WithCorrectSourceField_ReturnCursorMap(s *CodeUtilSuite, desc string) {
+func decodeNextKeys_WithCorrectSourceField_ReturnCursorMap(s *CodeUtilSuite, desc string) {
 	// prepare encoded string
 	cursorKey := "MainCategID:456,ID:123"
 	encodedString := base64.StdEncoding.EncodeToString([]byte(cursorKey))
@@ -116,16 +116,16 @@ func decodeCursor_WithCorrectSourceField_ReturnCursorMap(s *CodeUtilSuite, desc 
 	}
 
 	// action
-	result, err := codeutil.DecodeCursor(encodedString, fieldSource)
+	result, err := codeutil.DecodeNextKeys(encodedString, fieldSource)
 	s.Require().NoError(err, desc)
 	s.Require().Equal(cursorMap, result, desc)
 }
 
-func (s *CodeUtilSuite) TestEncodeCursor() {
+func (s *CodeUtilSuite) TestEncodeNextKeys() {
 	for scenario, fn := range map[string]func(*CodeUtilSuite, string){
-		"when the field is not found, return an error":            encodeCursor_FieldNotFound_ReturnErr,
-		"when the cursor map is valid, return encoded string":     encodeCursor_ValidCursorMap_ReturnEncodedString,
-		"when the field source is correct, return encoded string": encodeCursor_WithCorrectFieldSource_ReturnEncodedString,
+		"when the field is not found, return an error":            encodeNextKeys_FieldNotFound_ReturnErr,
+		"when the cursor map is valid, return encoded string":     encodeNextKeys_ValidCursorMap_ReturnEncodedString,
+		"when the field source is correct, return encoded string": encodeNextKeys_WithCorrectFieldSource_ReturnEncodedString,
 	} {
 		s.Run(testutil.GetFunName(fn), func() {
 			fn(s, scenario)
@@ -134,7 +134,7 @@ func (s *CodeUtilSuite) TestEncodeCursor() {
 
 }
 
-func encodeCursor_FieldNotFound_ReturnErr(s *CodeUtilSuite, desc string) {
+func encodeNextKeys_FieldNotFound_ReturnErr(s *CodeUtilSuite, desc string) {
 	// prepare next keys
 	nextKeys := domain.DecodedNextKeys{
 		{Field: "ID", Value: "123"},
@@ -147,7 +147,7 @@ func encodeCursor_FieldNotFound_ReturnErr(s *CodeUtilSuite, desc string) {
 	}{}
 
 	// action
-	result, err := codeutil.EncodeCursor(nextKeys, fieldSource)
+	result, err := codeutil.EncodeNextKeys(nextKeys, fieldSource)
 	s.Require().Empty(result, desc)
 	s.Require().Equal(codeutil.ErrFieldNotFound, err, desc)
 }
@@ -158,7 +158,7 @@ func encodeCursor_FieldNotFound_ReturnErr(s *CodeUtilSuite, desc string) {
 // Also, the output of the decoded string is random too
 // For example, the encoded string can be decoded to "ID:123,MainCategID:456" or "MainCategID:456,ID:123"
 // The only way we can check is to check the number of pairs and the value of the pairs respectively (using for loop)
-func encodeCursor_ValidCursorMap_ReturnEncodedString(s *CodeUtilSuite, desc string) {
+func encodeNextKeys_ValidCursorMap_ReturnEncodedString(s *CodeUtilSuite, desc string) {
 	// prepare next keys
 	nextKeys := domain.DecodedNextKeys{
 		{Field: "ID", Value: "123"},
@@ -169,7 +169,7 @@ func encodeCursor_ValidCursorMap_ReturnEncodedString(s *CodeUtilSuite, desc stri
 	expResult := "ID:123,MainCategID:456"
 
 	// action
-	result, err := codeutil.EncodeCursor(nextKeys, nil)
+	result, err := codeutil.EncodeNextKeys(nextKeys, nil)
 	s.Require().NoError(err, desc)
 
 	// check decoded string
@@ -178,7 +178,7 @@ func encodeCursor_ValidCursorMap_ReturnEncodedString(s *CodeUtilSuite, desc stri
 	s.Require().Equal(expResult, string(decodedBytes), desc)
 }
 
-func encodeCursor_WithCorrectFieldSource_ReturnEncodedString(s *CodeUtilSuite, desc string) {
+func encodeNextKeys_WithCorrectFieldSource_ReturnEncodedString(s *CodeUtilSuite, desc string) {
 	// prepare next keys
 	nextKeys := domain.DecodedNextKeys{
 		{Field: "MainCategID", Value: "456"},
@@ -198,7 +198,7 @@ func encodeCursor_WithCorrectFieldSource_ReturnEncodedString(s *CodeUtilSuite, d
 	expResult := "MainCategID:456new,ID:123"
 
 	// action
-	result, err := codeutil.EncodeCursor(nextKeys, fieldSource)
+	result, err := codeutil.EncodeNextKeys(nextKeys, fieldSource)
 	s.Require().NoError(err, desc)
 
 	// check encoded string


### PR DESCRIPTION
- change `decodedNextKey` type to slice of struct
   - because the order does matter when constructing the query statement 
- rename the function in the `codeutil`
- correct test case after refactoring 